### PR TITLE
feat: List messages in a conversation.

### DIFF
--- a/module/Olcs/src/Controller/ConversationsController.php
+++ b/module/Olcs/src/Controller/ConversationsController.php
@@ -81,9 +81,6 @@ class ConversationsController extends AbstractController implements ToggleAwareI
         ];
 
         $response = $this->handleQuery(ByConversationQuery::create($params));
-        if ($response === null) {
-            return $this->notFoundAction();
-        }
 
         if ($response->isOk()) {
             $messages = $response->getResult();

--- a/module/Olcs/src/Controller/ConversationsController.php
+++ b/module/Olcs/src/Controller/ConversationsController.php
@@ -9,6 +9,7 @@ use Common\Controller\Lva\AbstractController;
 use Common\FeatureToggle;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Table\TableFactory;
+use Dvsa\Olcs\Transfer\Query\Messaging\Messages\ByConversation as ByConversationQuery;
 use Dvsa\Olcs\Transfer\Query\Messaging\Conversations\ByOrganisation as ByOrganisationQuery;
 use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
 use Laminas\View\Model\ViewModel;
@@ -66,6 +67,36 @@ class ConversationsController extends AbstractController implements ToggleAwareI
 
         $view = new ViewModel(['table' => $table]);
         $view->setTemplate('messages');
+
+        return $view;
+    }
+
+    public function viewAction(): ViewModel
+    {
+        $params = [
+            'page'         => $this->params()->fromQuery('page', 1),
+            'limit'        => $this->params()->fromQuery('limit', 10),
+            'conversation' => $this->params()->fromRoute('conversationId'),
+            'query'        => $this->params()->fromQuery(),
+        ];
+
+        $response = $this->handleQuery(ByConversationQuery::create($params));
+        if ($response === null) {
+            return $this->notFoundAction();
+        }
+
+        if ($response->isOk()) {
+            $messages = $response->getResult();
+        } else {
+            $this->flashMessengerHelper->addErrorMessage('unknown-error');
+            $messages = [];
+        }
+
+        $table = $this->tableFactory
+            ->buildTable('messages-view', $messages, $params);
+
+        $view = new ViewModel(['table' => $table]);
+        $view->setTemplate('messages-view');
 
         return $view;
     }

--- a/module/Olcs/src/Table/Tables/messages-view.table.php
+++ b/module/Olcs/src/Table/Tables/messages-view.table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Common\Service\Table\Formatter\ExternalConversationMessage;
+
+return [
+    'attributes' => [
+        'class' => 'no-row-border-separator'
+    ],
+    'variables' => [
+        'id' => 'messages-list-table',
+        'title' => 'Messages',
+        'empty_message' => 'There are no message records linked to this conversation to display'
+    ],
+    'settings' => [
+        'paginate' => [
+            'limit' => [
+                'options' => [10, 25, 50],
+            ],
+        ],
+    ],
+    'columns' => [
+        [
+            'name' => 'id',
+            'formatter' => ExternalConversationMessage::class,
+        ],
+    ],
+];

--- a/module/Olcs/view/messages-view.phtml
+++ b/module/Olcs/view/messages-view.phtml
@@ -1,0 +1,27 @@
+<?php
+echo $this->partial(
+  'partials/page-header-simple',
+  [
+    'pageTitle' => $this->translate('dashboard.messages.view.title'),
+  ],
+);
+?>
+
+<div class="row">
+  <div class="dashboard two-thirds js-body">
+    <?php
+    echo $this->flashMessengerAll();
+
+    /* @var \Laminas\View\Helper\Navigation\Menu $menu */
+    $menu = $this->navigation($this->navigation('navigation')->getContainer()->findBy('id', 'dashboard-licences-applications'))->menu();
+
+    echo $menu->setMinDepth(0)
+              ->setMaxDepth(0)
+              ->setPartial('partials/tabs-nav');
+
+    echo $this->table;
+    ?>
+  </div>
+
+  <?php echo $this->partial('partials/dashboard-right-column'); ?>
+</div>

--- a/test/Olcs/src/Controller/ConversationsControllerTest.php
+++ b/test/Olcs/src/Controller/ConversationsControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace OlcsTest\Controller;
+
+use Common\Controller\Plugin\HandleQuery;
+use Common\Service\Cqrs\Response;
+use Common\Service\Helper\FlashMessengerHelperService;
+use Common\Service\Table\TableFactory;
+use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
+use Laminas\Mvc\Controller\Plugin\Params;
+use Laminas\View\Model\ViewModel;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
+use Olcs\Controller\ConversationsController as Sut;
+use ReflectionClass;
+use LmcRbacMvc\Service\AuthorizationService;
+
+class ConversationsControllerTest extends TestCase
+{
+    protected $sut;
+    protected $sm;
+
+    public function setUp(): void
+    {
+        $this->mockniTextTranslationUtil = m::mock(NiTextTranslation::class)->makePartial();
+        $this->mockauthService = m::mock(AuthorizationService::class)->makePartial();
+        $this->mockflashMessengerHelper = m::mock(FlashMessengerHelperService::class)->makePartial();
+        $this->mocktableFactory = m::mock(TableFactory::class)->makePartial();
+
+        $this->sut = m::mock(Sut::class)
+                      ->makePartial()
+                      ->shouldAllowMockingProtectedMethods();
+
+        $reflectionClass = new ReflectionClass(Sut::class);
+        $this->setMockedProperties($reflectionClass, 'niTextTranslationUtil', $this->mockniTextTranslationUtil);
+        $this->setMockedProperties($reflectionClass, 'authService', $this->mockauthService);
+        $this->setMockedProperties($reflectionClass, 'flashMessengerHelper', $this->mockflashMessengerHelper);
+        $this->setMockedProperties($reflectionClass, 'tableFactory', $this->mocktableFactory);
+    }
+
+    public function setMockedProperties(ReflectionClass $reflectionClass, string $property, $value): void
+    {
+        $reflectionProperty = $reflectionClass->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($this->sut, $value);
+    }
+
+    public function testViewAction(): void
+    {
+        $mockResponse = m::mock(Response::class);
+        $mockResponse->shouldReceive('isOk')
+                     ->andReturn(true);
+        $mockResponse->shouldReceive('getResult')
+                     ->andReturn([]);
+
+        $mockHandleQuery = m::mock(HandleQuery::class)
+                            ->makePartial();
+        $mockHandleQuery->shouldReceive('__invoke')
+                        ->andReturn($mockResponse);
+
+        $mockParams = m::mock(Params::class);
+        $mockParams->shouldReceive('fromQuery')
+                   ->with('page', 1)
+                   ->andReturn(1);
+        $mockParams->shouldReceive('fromQuery')
+                   ->with('limit', 10)
+                   ->andReturn(10);
+        $mockParams->shouldReceive('fromQuery')
+                   ->withNoArgs()
+                   ->andReturn([]);
+        $mockParams->shouldReceive('fromRoute')
+                   ->with('conversationId')
+                   ->andReturn(1);
+
+        $this->sut->shouldReceive('params')
+                  ->andReturn($mockParams);
+        $this->sut->shouldReceive('plugin')
+                  ->with('handleQuery')
+                  ->andReturn($mockHandleQuery);
+
+        $table = '<table/>';
+
+        $this->mocktableFactory->shouldReceive('buildTable')
+                               ->with(
+                                   'messages-view',
+                                   [],
+                                   ['page' => 1, 'limit' => 10, 'conversation' => 1, 'query' => []],
+                               )
+                               ->andReturn($table);
+
+        $view = $this->sut->viewAction();
+        $this->assertInstanceOf(ViewModel::class, $view);
+        $this->assertEquals($table, $view->getVariable('table'));
+    }
+}

--- a/test/Olcs/src/Controller/ConversationsControllerTest.php
+++ b/test/Olcs/src/Controller/ConversationsControllerTest.php
@@ -17,25 +17,24 @@ use LmcRbacMvc\Service\AuthorizationService;
 
 class ConversationsControllerTest extends TestCase
 {
-    protected $sut;
-    protected $sm;
+    protected    $sut;
 
     public function setUp(): void
     {
-        $this->mockniTextTranslationUtil = m::mock(NiTextTranslation::class)->makePartial();
-        $this->mockauthService = m::mock(AuthorizationService::class)->makePartial();
-        $this->mockflashMessengerHelper = m::mock(FlashMessengerHelperService::class)->makePartial();
-        $this->mocktableFactory = m::mock(TableFactory::class)->makePartial();
+        $this->mockNiTextTranslationUtil = m::mock(NiTextTranslation::class)->makePartial();
+        $this->mockAuthService = m::mock(AuthorizationService::class)->makePartial();
+        $this->mockFlashMessengerHelper = m::mock(FlashMessengerHelperService::class)->makePartial();
+        $this->mockTableFactory = m::mock(TableFactory::class)->makePartial();
 
         $this->sut = m::mock(Sut::class)
                       ->makePartial()
                       ->shouldAllowMockingProtectedMethods();
 
         $reflectionClass = new ReflectionClass(Sut::class);
-        $this->setMockedProperties($reflectionClass, 'niTextTranslationUtil', $this->mockniTextTranslationUtil);
-        $this->setMockedProperties($reflectionClass, 'authService', $this->mockauthService);
-        $this->setMockedProperties($reflectionClass, 'flashMessengerHelper', $this->mockflashMessengerHelper);
-        $this->setMockedProperties($reflectionClass, 'tableFactory', $this->mocktableFactory);
+        $this->setMockedProperties($reflectionClass, 'niTextTranslationUtil', $this->mockNiTextTranslationUtil);
+        $this->setMockedProperties($reflectionClass, 'authService', $this->mockAuthService);
+        $this->setMockedProperties($reflectionClass, 'flashMessengerHelper', $this->mockFlashMessengerHelper);
+        $this->setMockedProperties($reflectionClass, 'tableFactory', $this->mockTableFactory);
     }
 
     public function setMockedProperties(ReflectionClass $reflectionClass, string $property, $value): void
@@ -80,7 +79,7 @@ class ConversationsControllerTest extends TestCase
 
         $table = '<table/>';
 
-        $this->mocktableFactory->shouldReceive('buildTable')
+        $this->mockTableFactory->shouldReceive('buildTable')
                                ->with(
                                    'messages-view',
                                    [],

--- a/test/Olcs/src/Controller/ConversationsControllerTest.php
+++ b/test/Olcs/src/Controller/ConversationsControllerTest.php
@@ -17,7 +17,7 @@ use LmcRbacMvc\Service\AuthorizationService;
 
 class ConversationsControllerTest extends TestCase
 {
-    protected    $sut;
+    protected $sut;
 
     public function setUp(): void
     {


### PR DESCRIPTION
## Description

Case worker can select a conversation, they are then taken to a page where they can view the messages related to that conversation.

Related issue: [VOL-4805](https://dvsa.atlassian.net/browse/VOL-4805)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
