### PR TITLE
fix: Two constructor params were recently added, only one was being u…

### DIFF
--- a/module/Olcs/src/Controller/Lva/Variation/FinancialEvidenceController.php
+++ b/module/Olcs/src/Controller/Lva/Variation/FinancialEvidenceController.php
@@ -49,8 +49,7 @@ class FinancialEvidenceController extends Lva\AbstractFinancialEvidenceControlle
         AnnotationBuilder $transferAnnotationBuilder,
         CommandService $commandService,
         Lva\Adapters\VariationFinancialEvidenceAdapter $lvaAdapter,
-        FileUploadHelperService $uploadHelper,
-        ValidatorPluginManager $validatorPluginManager
+        FileUploadHelperService $uploadHelper
     ) {
         parent::__construct(
             $niTextTranslationUtil,


### PR DESCRIPTION
…sed and the other not passed in from the factory. Removed the unused one. Page now tests OK locally.

`module/Olcs/src/Controller/Lva/Variation/FinancialEvidenceController.php` Recently refactored adding two constructor parameters. Only one was being used and passed in from factory, other absent in factory. Removed, tested page locally. Works OK now.

Related issue: [VOL-4883](https://dvsa.atlassian.net/browse/VOL-4883)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
