### PR TITLE
fix: replace `laminas-form` with patched fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,10 @@
 {
     "name": "olcs/olcs-selfserve",
     "description": "OLCS Self Service Web Site",
+    "repositories": [{
+       "type": "vcs",
+       "url": "https://github.com/JoshuaLicense/laminas-form.git"
+    }],
     "require": {
         "php": "^7.4",
         "doctrine/annotations": "^1.14.2",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "OLCS Self Service Web Site",
     "repositories": [{
        "type": "vcs",
-       "url": "https://github.com/JoshuaLicense/laminas-form.git"
+       "url": "https://github.com/dvsa/laminas-form.git"
     }],
     "require": {
         "php": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "497ef053eff38cf4431cc8be0e0d444e",
+    "content-hash": "ee109a47f556b23ead54adbd0e62c99e",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1815,13 +1815,13 @@
             "version": "3.4.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/JoshuaLicense/laminas-form.git",
-                "reference": "733ea7eda2689147a6b2f7ad86d00133eea1f421"
+                "url": "https://github.com/dvsa/laminas-form.git",
+                "reference": "246a46c1a926fd4d7ce227e251118106f73ea2fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JoshuaLicense/laminas-form/zipball/733ea7eda2689147a6b2f7ad86d00133eea1f421",
-                "reference": "733ea7eda2689147a6b2f7ad86d00133eea1f421",
+                "url": "https://api.github.com/repos/dvsa/laminas-form/zipball/246a46c1a926fd4d7ce227e251118106f73ea2fe",
+                "reference": "246a46c1a926fd4d7ce227e251118106f73ea2fe",
                 "shasum": ""
             },
             "require": {
@@ -1926,7 +1926,7 @@
                 "docs": "https://docs.laminas.dev/laminas-form/",
                 "rss": "https://github.com/laminas/laminas-form/releases.atom"
             },
-            "time": "2024-01-26T11:35:31+00:00"
+            "time": "2024-01-26T11:54:40+00:00"
         },
         {
             "name": "laminas/laminas-http",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b84b5dc026d0ee153cd48a27959cd63e",
+    "content-hash": "497ef053eff38cf4431cc8be0e0d444e",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1812,16 +1812,16 @@
         },
         {
             "name": "laminas/laminas-form",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laminas/laminas-form.git",
-                "reference": "cd3f9d3e345b075d34793e46b0759a4dfd12f674"
+                "url": "https://github.com/JoshuaLicense/laminas-form.git",
+                "reference": "733ea7eda2689147a6b2f7ad86d00133eea1f421"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/cd3f9d3e345b075d34793e46b0759a4dfd12f674",
-                "reference": "cd3f9d3e345b075d34793e46b0759a4dfd12f674",
+                "url": "https://api.github.com/repos/JoshuaLicense/laminas-form/zipball/733ea7eda2689147a6b2f7ad86d00133eea1f421",
+                "reference": "733ea7eda2689147a6b2f7ad86d00133eea1f421",
                 "shasum": ""
             },
             "require": {
@@ -1882,7 +1882,33 @@
                     "Laminas\\Form\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "LaminasTest\\Form\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@static-analysis",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "static-analysis": [
+                    "psalm --shepherd --stats"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -1893,20 +1919,14 @@
                 "laminas"
             ],
             "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-form/",
-                "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-form/issues",
-                "rss": "https://github.com/laminas/laminas-form/releases.atom",
-                "source": "https://github.com/laminas/laminas-form"
+                "forum": "https://discourse.laminas.dev",
+                "chat": "https://laminas.dev/chat",
+                "source": "https://github.com/laminas/laminas-form",
+                "docs": "https://docs.laminas.dev/laminas-form/",
+                "rss": "https://github.com/laminas/laminas-form/releases.atom"
             },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-08-01T09:48:44+00:00"
+            "time": "2024-01-26T11:35:31+00:00"
         },
         {
             "name": "laminas/laminas-http",


### PR DESCRIPTION
## Description

Laminas Form had an [issue](https://github.com/laminas/laminas-form/commit/733ea7eda2689147a6b2f7ad86d00133eea1f421) that was resolved only in v3.9.0 onwards. We use Laminas Form v3.4.x due to PHP version constraints. The fork that this now points to simply cherry-picks that commit until a point we can point back to the latest Laminas form version (PHP upgrade epic).

Related issue: https://dvsa.atlassian.net/browse/VOL-4871
