### PR TITLE
feat: Message list split in to two columns

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3987,12 +3987,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-common.git",
-                "reference": "13d1f6b8cbb30e6f2d88aeb3d1208fb44aae5ca3"
+                "reference": "f1403681db7501e3429540951938e43b20069e37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/13d1f6b8cbb30e6f2d88aeb3d1208fb44aae5ca3",
-                "reference": "13d1f6b8cbb30e6f2d88aeb3d1208fb44aae5ca3",
+                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/f1403681db7501e3429540951938e43b20069e37",
+                "reference": "f1403681db7501e3429540951938e43b20069e37",
                 "shasum": ""
             },
             "require": {
@@ -4052,7 +4052,7 @@
             "support": {
                 "source": "https://github.com/dvsa/olcs-common/tree/project/messaging"
             },
-            "time": "2024-01-29T14:40:21+00:00"
+            "time": "2024-01-30T15:47:21+00:00"
         },
         {
             "name": "olcs/olcs-logging",

--- a/module/Olcs/src/Table/Tables/messages.table.php
+++ b/module/Olcs/src/Table/Tables/messages.table.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Common\Service\Table\Formatter\ExternalConversationLink;
+use Common\Service\Table\Formatter\ExternalConversationStatus;
 
 return [
     'variables'  => [
@@ -25,8 +26,14 @@ return [
     'attributes' => [],
     'columns'    => [
         [
-            'name' => 'id',
+            'title'     => 'Subject',
+            'name'      => 'id',
             'formatter' => ExternalConversationLink::class,
+        ],
+        [
+            'title'     => 'Status',
+            'name'      => 'status',
+            'formatter' => ExternalConversationStatus::class,
         ],
     ],
 ];


### PR DESCRIPTION
## Description

External message list should be split in to two columns with status in the right column.

Related issue: [VOL-4805](https://dvsa.atlassian.net/browse/VOL-4805)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
