### PR TITLE
fix: consolidate `Navigation` and `navigation`

### DIFF
--- a/module/Olcs/config/module.config.php
+++ b/module/Olcs/config/module.config.php
@@ -1407,7 +1407,6 @@ return array(
             'CookieDeleteCookieNamesProvider' => CookieService\DeleteCookieNamesProviderFactory::class,
             ProcessingService\DashboardProcessingService::class => ProcessingService\DashboardProcessingServiceFactory::class,
             'Olcs\InputFilter\EbsrPackInput' => \Olcs\InputFilter\EbsrPackFactory::class,
-            'navigation' => Laminas\Navigation\Service\DefaultNavigationFactory::class,
             'Olcs\Navigation\DashboardNavigation' => Olcs\Navigation\DashboardNavigationFactory::class,
             Olcs\Controller\Listener\Navigation::class => Olcs\Controller\Listener\NavigationFactory::class,
             'QaFormProvider' => QaService\FormProviderFactory::class,

--- a/module/Olcs/src/Controller/Factory/Search/SearchControllerFactory.php
+++ b/module/Olcs/src/Controller/Factory/Search/SearchControllerFactory.php
@@ -25,7 +25,7 @@ class SearchControllerFactory implements FactoryInterface
         $authService = $container->get(AuthorizationService::class);
         $scriptFactory = $container->get(ScriptFactory::class);
         $formHelper = $container->get(FormHelperService::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
         $formElementManager = $container->get('FormElementManager');
         $viewHelperManager = $container->get('ViewHelperManager');
         $dataServiceManager = $container->get('DataServiceManager');


### PR DESCRIPTION
## Description

The projects were using a mix of `Navigation` and `navigation` resulting in two different objects - this caused issues with navigation as two different objects were being mutated and used.

I went with `navigation` even though it was a larger refactor due to that being the alias that is registered in the upstream package: https://github.com/laminas/laminas-navigation/blob/2f39ab2f929d23da89bbb4401efdccb6e72eaf68/src/ConfigProvider.php#L33.

Related issue:  https://dvsa.atlassian.net/browse/VOL-4900 & https://dvsa.atlassian.net/browse/VOL-4915

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
