### PR TITLE
fix: Old string formatter name to FQCN and Import.

### DIFF
--- a/module/Olcs/src/Table/Tables/txc-inbox.table.php
+++ b/module/Olcs/src/Table/Tables/txc-inbox.table.php
@@ -2,6 +2,7 @@
 
 use Common\Service\Table\Formatter\BusRegStatus;
 use Common\Service\Table\Formatter\EbsrRegNumberLink;
+use Common\Service\Table\Formatter\EbsrVariationNumber;
 use Common\Service\Table\Formatter\StackValue;
 
 return array(
@@ -47,7 +48,7 @@ return array(
             'title' => 'selfserve-table-txc-inbox-variation',
             'isNumeric' => true,
             'formatter' => function ($data, $column) {
-                $column['formatter'] = 'EbsrVariationNumber';
+                $column['formatter'] = EbsrVariationNumber::class;
                 return $this->callFormatter($column, $data);
             }
         ),


### PR DESCRIPTION
## Description

Replace formatter string name with proper class and use stmt.

Related issue: [4926](https://dvsa.atlassian.net/browse/VOL-4926)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
