### PR TITLE
Add "Messaging not disabled" to tab display conditions

### DIFF
--- a/module/Olcs/src/Controller/Listener/Navigation.php
+++ b/module/Olcs/src/Controller/Listener/Navigation.php
@@ -172,12 +172,18 @@ class Navigation implements ListenerAggregateInterface
 
     private function shouldShowMessagesTab(): bool
     {
-        $messagingToggleState = $this->querySender->featuresEnabled([FeatureToggle::MESSAGING]);
+        $messagingToggleEnabled = $this->querySender->featuresEnabled([FeatureToggle::MESSAGING]);
+
+        $userData = $this->identity->getUserData();
+
+        $hasOrganisationSubmittedLicenceApplication = $userData['hasOrganisationSubmittedLicenceApplication'];
+
+        $isMessagingEnabled = $this->identity->$userData['organisationUsers'][0]['organisation']['isMessagingDisabled'] === false;
 
         return (
-            $messagingToggleState &&
-            $this->identity->getUserData()['hasOrganisationSubmittedLicenceApplication'] &&
-            $this->identity->getUserData()['organisationUsers'][0]['organisation']['isMessagingDisabled'] === false
+            $messagingToggleEnabled &&
+            $hasOrganisationSubmittedLicenceApplication &&
+            $isMessagingEnabled
         );
     }
 

--- a/module/Olcs/src/Controller/Listener/Navigation.php
+++ b/module/Olcs/src/Controller/Listener/Navigation.php
@@ -172,11 +172,13 @@ class Navigation implements ListenerAggregateInterface
 
     private function shouldShowMessagesTab(): bool
     {
-        $hasPendingOrValidLicence = $this->identity->getUserData()['hasOrganisationSubmittedLicenceApplication'];
-
         $messagingToggleState = $this->querySender->featuresEnabled([FeatureToggle::MESSAGING]);
 
-        return $messagingToggleState && $hasPendingOrValidLicence;
+        return (
+            $messagingToggleState &&
+            $this->identity->getUserData()['hasOrganisationSubmittedLicenceApplication'] &&
+            $this->identity->getUserData()['organisationUsers'][0]['organisation']['isMessagingDisabled'] === false
+        );
     }
 
     /**

--- a/module/Olcs/src/Controller/Listener/Navigation.php
+++ b/module/Olcs/src/Controller/Listener/Navigation.php
@@ -178,7 +178,7 @@ class Navigation implements ListenerAggregateInterface
 
         $hasOrganisationSubmittedLicenceApplication = $userData['hasOrganisationSubmittedLicenceApplication'];
 
-        $isMessagingEnabled = $this->identity->$userData['organisationUsers'][0]['organisation']['isMessagingDisabled'] === false;
+        $isMessagingEnabled = $userData['organisationUsers'][0]['organisation']['isMessagingDisabled'] === false;
 
         return (
             $messagingToggleEnabled &&

--- a/test/Olcs/src/Controller/Listener/NavigationTest.php
+++ b/test/Olcs/src/Controller/Listener/NavigationTest.php
@@ -234,6 +234,7 @@ class NavigationTest extends m\Adapter\Phpunit\MockeryTestCase
                     ]
                 ]
             ]);
+
         $this->mockNavigation
             ->shouldReceive('findBy')
             ->twice()

--- a/test/Olcs/src/Controller/Listener/NavigationTest.php
+++ b/test/Olcs/src/Controller/Listener/NavigationTest.php
@@ -59,7 +59,18 @@ class NavigationTest extends m\Adapter\Phpunit\MockeryTestCase
     {
         $this->mockIdentity->shouldReceive('isAnonymous')->once()->withNoArgs()->andReturn(true);
 
-        $this->mockIdentity->expects('getUserData')->once()->andReturn(['hasOrganisationSubmittedLicenceApplication' => false]);
+        $this->mockIdentity->expects('getUserData')
+            ->once()
+            ->andReturn([
+                'hasOrganisationSubmittedLicenceApplication' => false,
+                'organisationUsers' => [
+                    0 => [
+                        'organisation' => [
+                            'isMessagingDisabled' => false
+                        ]
+                    ]
+                ]
+            ]);
 
         $this->mockQuerySender->shouldReceive('featuresEnabled')->with([$this->messagingToggle])->once();
 
@@ -101,9 +112,20 @@ class NavigationTest extends m\Adapter\Phpunit\MockeryTestCase
     public function testOnDispatchWithNoReferal($eligibleForPermits)
     {
         $this->mockIdentity->shouldReceive('isAnonymous')->once()->withNoArgs()->andReturn(false);
+
         $this->mockIdentity->expects('getUserData')
             ->twice()
-            ->andReturn(['eligibleForPermits' => $eligibleForPermits, 'hasOrganisationSubmittedLicenceApplication' => false]);
+            ->andReturn([
+                'eligibleForPermits' => $eligibleForPermits,
+                'hasOrganisationSubmittedLicenceApplication' => false,
+                'organisationUsers' => [
+                    0 => [
+                        'organisation' => [
+                            'isMessagingDisabled' => false
+                        ]
+                    ]
+                ]
+            ]);
 
         $this->mockQuerySender->shouldReceive('featuresEnabled')->with([$this->messagingToggle])->once();
 
@@ -155,7 +177,16 @@ class NavigationTest extends m\Adapter\Phpunit\MockeryTestCase
 
         $this->mockIdentity->expects('getUserData')
             ->once()
-            ->andReturn(['hasOrganisationSubmittedLicenceApplication' => false]);
+            ->andReturn([
+                'hasOrganisationSubmittedLicenceApplication' => false,
+                'organisationUsers' => [
+                    0 => [
+                        'organisation' => [
+                            'isMessagingDisabled' => false
+                        ]
+                    ]
+                ]
+            ]);
 
         $this->mockQuerySender->shouldReceive('featuresEnabled')->once()->with([$this->messagingToggle]);
 
@@ -192,8 +223,17 @@ class NavigationTest extends m\Adapter\Phpunit\MockeryTestCase
 
         $this->mockIdentity->expects('getUserData')
             ->twice()
-            ->andReturn(['eligibleForPermits' => $eligibleForPermits, 'hasOrganisationSubmittedLicenceApplication' => false]);
-
+            ->andReturn([
+                'eligibleForPermits' => $eligibleForPermits,
+                'hasOrganisationSubmittedLicenceApplication' => false,
+                'organisationUsers' => [
+                    0 => [
+                        'organisation' => [
+                            'isMessagingDisabled' => false
+                        ]
+                    ]
+                ]
+            ]);
         $this->mockNavigation
             ->shouldReceive('findBy')
             ->twice()


### PR DESCRIPTION
## Description

Changes rule to not show messaging tab on selfserve when messaging is disabled.

Related issue: [VOL-4713](https://dvsa.atlassian.net/browse/VOL-4713)

Specifically, AC5 and the comment relating to it.

See also: [VOL-4920](https://dvsa.atlassian.net/browse/VOL-4920)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
