### PR TITLE
fix: Trying to access array key on null in navigation

### DIFF
--- a/module/Olcs/src/Controller/Listener/Navigation.php
+++ b/module/Olcs/src/Controller/Listener/Navigation.php
@@ -178,7 +178,10 @@ class Navigation implements ListenerAggregateInterface
 
         $hasOrganisationSubmittedLicenceApplication = $userData['hasOrganisationSubmittedLicenceApplication'];
 
-        $isMessagingEnabled = $userData['organisationUsers'][0]['organisation']['isMessagingDisabled'] === false;
+        $isMessagingEnabled = false;
+        if (isset($userData['organisationUsers'][0]['organisation']['isMessagingDisabled'])) {
+            $isMessagingEnabled = $userData['organisationUsers'][0]['organisation']['isMessagingDisabled'] === false;
+        }
 
         return (
             $messagingToggleEnabled &&


### PR DESCRIPTION
## Description

Navigation.php throwing a notice due to array key not always existing.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
