### PR TITLE
chore: revert composer.json/lock to use non-messaging project branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         "laminas/laminas-view": "^2.11",
         "lm-commons/lmc-rbac-mvc": "^3.3",
         "olcs/olcs-auth": "^5.0.0",
-        "olcs/olcs-common": "dev-project/messaging",
+        "olcs/olcs-common": "^5.0.0",
         "olcs/olcs-logging": "^5.0.0",
-        "olcs/olcs-transfer": "dev-project/messaging",
+        "olcs/olcs-transfer": "^5.0.0",
         "olcs/olcs-utils": "^5.0.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "067ae936d33e9d06aaa37473801b3d73",
+    "content-hash": "ee109a47f556b23ead54adbd0e62c99e",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -3983,16 +3983,16 @@
         },
         {
             "name": "olcs/olcs-common",
-            "version": "dev-project/messaging",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-common.git",
-                "reference": "52b009ca228a8cb7a19b12b2a07bc54deff467b8"
+                "reference": "73b1c0cf809b50138dd1f5b471905361f1cd868e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/52b009ca228a8cb7a19b12b2a07bc54deff467b8",
-                "reference": "52b009ca228a8cb7a19b12b2a07bc54deff467b8",
+                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/73b1c0cf809b50138dd1f5b471905361f1cd868e",
+                "reference": "73b1c0cf809b50138dd1f5b471905361f1cd868e",
                 "shasum": ""
             },
             "require": {
@@ -4015,7 +4015,7 @@
                 "laminas/laminas-validator": "^2.11",
                 "laminas/laminas-view": "^2.11",
                 "olcs/olcs-logging": "^5.0.0",
-                "olcs/olcs-transfer": "dev-project/messaging",
+                "olcs/olcs-transfer": "^5.0.0",
                 "olcs/olcs-utils": "^5.0",
                 "php": "^7.4"
             },
@@ -4050,9 +4050,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "Common library for the OLCS Project",
             "support": {
-                "source": "https://github.com/dvsa/olcs-common/tree/project/messaging"
+                "source": "https://github.com/dvsa/olcs-common/tree/v5.1.1"
             },
-            "time": "2024-02-13T10:49:40+00:00"
+            "time": "2024-02-16T10:40:20+00:00"
         },
         {
             "name": "olcs/olcs-logging",
@@ -4108,16 +4108,16 @@
         },
         {
             "name": "olcs/olcs-transfer",
-            "version": "dev-project/messaging",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-transfer.git",
-                "reference": "48253e03297ea382792f1ac5c7f84b9a5839c916"
+                "reference": "b1fe910e1dafbf495367d16fe1953cf1aa9f88b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/48253e03297ea382792f1ac5c7f84b9a5839c916",
-                "reference": "48253e03297ea382792f1ac5c7f84b9a5839c916",
+                "url": "https://api.github.com/repos/dvsa/olcs-transfer/zipball/b1fe910e1dafbf495367d16fe1953cf1aa9f88b6",
+                "reference": "b1fe910e1dafbf495367d16fe1953cf1aa9f88b6",
                 "shasum": ""
             },
             "require": {
@@ -4157,9 +4157,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "OLCS Transfer",
             "support": {
-                "source": "https://github.com/dvsa/olcs-transfer/tree/project/messaging"
+                "source": "https://github.com/dvsa/olcs-transfer/tree/v5.1.0"
             },
-            "time": "2024-02-09T14:53:43+00:00"
+            "time": "2024-02-16T10:21:39+00:00"
         },
         {
             "name": "olcs/olcs-utils",
@@ -8014,10 +8014,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "olcs/olcs-common": 20,
-        "olcs/olcs-transfer": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -8027,5 +8024,5 @@
     "platform-overrides": {
         "ext-redis": "4.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Description

chore: revert composer.json/lock to use non-messaging project branches

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
