### PR TITLE
fix: Hide file upload if uploads disabled.

### DIFF
--- a/test/Olcs/src/Controller/ConversationsControllerTest.php
+++ b/test/Olcs/src/Controller/ConversationsControllerTest.php
@@ -45,6 +45,7 @@ class ConversationsControllerTest extends TestCase
         $this->mockForm = m::mock(Form::class);
         $this->mockParams = m::mock(Params::class);
         $this->mockUploadHelper = m::mock(FileUploadHelperService::class);
+        $this->mockUser = m::mock(User::class);
 
         $this->sut = m::mock(Sut::class)
                       ->makePartial()
@@ -122,8 +123,7 @@ class ConversationsControllerTest extends TestCase
                          ->with('conversationId')
                          ->andReturn(1);
 
-        $mockUser = m::mock(User::class);
-        $mockUser->shouldReceive('getUserData')
+        $this->mockUser->shouldReceive('getUserData')
                  ->once()
                  ->andReturn(
                      [
@@ -150,7 +150,7 @@ class ConversationsControllerTest extends TestCase
                   ->andReturn($mockHandleQuery);
         $this->sut->shouldReceive('plugin')
                   ->with('currentUser')
-                  ->andReturn($mockUser);
+                  ->andReturn($this->mockUser);
         $this->sut->shouldReceive('plugin')
                   ->with('url')
                   ->once()
@@ -329,6 +329,20 @@ class ConversationsControllerTest extends TestCase
                   ->once()
                   ->with('redirect')
                   ->andReturn($mockRedirect);
+
+        $this->mockUser->shouldReceive('getUserData')
+                       ->once()
+                       ->andReturn(
+                           [
+                               'organisationUsers' => [
+                                   [
+                                       'organisation' => [
+                                           'isMessagingFileUploadEnabled' => true,
+                                       ],
+                                   ],
+                               ],
+                           ],
+                       );
 
         $this->testViewAction();
     }


### PR DESCRIPTION
## Description

If uploads for messaging is disabled, hide the button on reply.

Related issue: [VOL-4393](https://dvsa.atlassian.net/browse/VOL-4393)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
