### PR TITLE
fix: add `chdir` to `govukaccount-redirect` to pickup correct cache dir

### DIFF
--- a/public/govukaccount-redirect.php
+++ b/public/govukaccount-redirect.php
@@ -2,6 +2,8 @@
 
     declare(strict_types=1);
 
+    chdir(dirname(__DIR__));
+
     include __DIR__ . '/../vendor/autoload.php';
 
     $container = require __DIR__ . '/../config/container.php';


### PR DESCRIPTION
## Description

Cache directory is relative. This works as `public/index.php` switches the current working directory on each request. `govukaccount-redirect` doesn't go through the `public/index.php`. This PR adds the same `chdir` instruction to this entrypoint.

Related issue: Regression from https://dvsa.atlassian.net/browse/VOL-4492.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
