### PR TITLE
fix: Confirmation page declared tma different to trait

### DIFF
--- a/module/Olcs/src/Controller/Lva/TransportManager/ConfirmationController.php
+++ b/module/Olcs/src/Controller/Lva/TransportManager/ConfirmationController.php
@@ -21,8 +21,6 @@ class ConfirmationController extends AbstractController
 
     public const OPERATOR_MARKUP = 'markup-tma-confirmation-operator';
 
-    protected $tma;
-
     protected $markup = self::OPERATOR_MARKUP;
 
     protected $signature;


### PR DESCRIPTION
## Description

Another controller user the TM trait re-declared the variable.

Related issue: [VOL-5207 ](https://dvsa.atlassian.net/browse/VOL-5207)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
