### PR TITLE
fix: VOL-5243 remove buttons now showing correctly on the manage users page

### DIFF
--- a/module/Olcs/src/Table/Tables/users.table.php
+++ b/module/Olcs/src/Table/Tables/users.table.php
@@ -66,7 +66,7 @@ return [
                  * @var TableBuilder $this
                  * @psalm-scope-this TableBuilder
                  */
-                $this->permissionService->isSelf($row['id']),
+                $this->permissionService->canManageSelfserveUsers(),
             'ariaDescription' => function ($row, $column) {
                 $column['formatter'] = Name::class;
                 /**


### PR DESCRIPTION
## Description

Bug meant it wasn't possible for admin users to remove selfservice users for their organisation, this fixes it.

Requires bump of olcs-common after this PR merged:
https://github.com/dvsa/olcs-common/pull/98

Related issue: [VOL-5243](https://dvsa.atlassian.net/browse/VOL-5243)
