### PR TITLE
fix: Don't allow deleting pre submission file uploads

### DIFF
--- a/module/Olcs/src/Controller/Lva/AbstractUploadEvidenceController.php
+++ b/module/Olcs/src/Controller/Lva/AbstractUploadEvidenceController.php
@@ -8,7 +8,6 @@ use Common\Form\Form;
 use Common\RefData;
 use Common\Service\Helper\FileUploadHelperService;
 use Common\Service\Helper\FormHelperService;
-use DateTimeImmutable;
 use Dvsa\Olcs\Transfer\Query\Application\UploadEvidence;
 use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
 use Olcs\Controller\Lva\Traits\ApplicationControllerTrait;

--- a/module/Olcs/src/Controller/Lva/AbstractUploadEvidenceController.php
+++ b/module/Olcs/src/Controller/Lva/AbstractUploadEvidenceController.php
@@ -8,6 +8,7 @@ use Common\Form\Form;
 use Common\RefData;
 use Common\Service\Helper\FileUploadHelperService;
 use Common\Service\Helper\FormHelperService;
+use DateTimeImmutable;
 use Dvsa\Olcs\Transfer\Query\Application\UploadEvidence;
 use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
 use Olcs\Controller\Lva\Traits\ApplicationControllerTrait;
@@ -287,15 +288,10 @@ abstract class AbstractUploadEvidenceController extends AbstractController
         $this->getFinancialEvidenceData(true);
     }
 
-    /**
-     * Get list of financial evidence documents
-     *
-     * @return array
-     */
-    public function financialEvidenceLoadFileUpload()
+    /** Get list of financial evidence documents */
+    public function financialEvidenceLoadFileUpload(): array
     {
-        $financialEvidenceData = $this->getFinancialEvidenceData();
-        return $financialEvidenceData['documents'];
+        return array_filter($this->getFinancialEvidenceData()['documents'], fn($doc) => $doc['isPostSubmissionUpload']);
     }
 
     /**
@@ -324,14 +320,10 @@ abstract class AbstractUploadEvidenceController extends AbstractController
         $this->getData(true);
     }
 
-    /**
-     * Get list of supporting evidence documents
-     *
-     * @return array
-     */
-    public function supportingEvidenceLoadFileUpload()
+    /** Get list of supporting evidence documents */
+    public function supportingEvidenceLoadFileUpload(): array
     {
-        return $this->getData()['supportingEvidence'];
+        return array_filter($this->getData()['supportingEvidence'], fn($doc) => $doc['isPostSubmissionUpload']);
     }
 
     /**


### PR DESCRIPTION
## Description

There is currently a bug in VOL production which is allowing operators to remove documents previously uploaded as part of a new or variation application, after the application is submitted and status is ‘under consideration’.

Related issue: [VOL-3200](https://dvsa.atlassian.net/browse/VOL-3200)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
