### PR TITLE
chore: VOL-5402 remove reliance on forked laminas-form package bump to 3.19.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,6 @@
 {
     "name": "olcs/olcs-selfserve",
     "description": "OLCS Self Service Web Site",
-    "repositories": [{
-       "type": "vcs",
-       "url": "https://github.com/dvsa/laminas-form.git"
-    }],
     "require": {
         "php": "~8.2.0",
         "ext-redis": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e795743d0a9ad07d40e153c7fa02910",
+    "content-hash": "b2a7bd4a1a124b023469a98fb28e4e4e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2218,16 +2218,16 @@
         },
         {
             "name": "laminas/laminas-form",
-            "version": "3.19.1",
+            "version": "3.19.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/dvsa/laminas-form.git",
-                "reference": "c6f6c68f9b7f0793a805b10309198ad455ca900e"
+                "url": "https://github.com/laminas/laminas-form.git",
+                "reference": "f2ae01f6574ff9ca5139232c168e80b557b2b2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/laminas-form/zipball/c6f6c68f9b7f0793a805b10309198ad455ca900e",
-                "reference": "c6f6c68f9b7f0793a805b10309198ad455ca900e",
+                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/f2ae01f6574ff9ca5139232c168e80b557b2b2aa",
+                "reference": "f2ae01f6574ff9ca5139232c168e80b557b2b2aa",
                 "shasum": ""
             },
             "require": {
@@ -2287,33 +2287,7 @@
                     "Laminas\\Form\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "LaminasTest\\Form\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@cs-check",
-                    "@static-analysis",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "static-analysis": [
-                    "psalm --shepherd --stats"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -2324,14 +2298,20 @@
                 "laminas"
             ],
             "support": {
-                "issues": "https://github.com/laminas/laminas-form/issues",
-                "forum": "https://discourse.laminas.dev",
                 "chat": "https://laminas.dev/chat",
-                "source": "https://github.com/laminas/laminas-form",
                 "docs": "https://docs.laminas.dev/laminas-form/",
-                "rss": "https://github.com/laminas/laminas-form/releases.atom"
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-form/issues",
+                "rss": "https://github.com/laminas/laminas-form/releases.atom",
+                "source": "https://github.com/laminas/laminas-form"
             },
-            "time": "2024-01-11T15:32:31+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-02-19T07:08:43+00:00"
         },
         {
             "name": "laminas/laminas-http",
@@ -4436,16 +4416,16 @@
         },
         {
             "name": "olcs/olcs-common",
-            "version": "v7.2.3",
+            "version": "v7.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-common.git",
-                "reference": "221b1c97b2171e6e9edd34b088d81583236490bd"
+                "reference": "cc552c3562ab904d9270fb771f6d3e9fac98b8b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/221b1c97b2171e6e9edd34b088d81583236490bd",
-                "reference": "221b1c97b2171e6e9edd34b088d81583236490bd",
+                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/cc552c3562ab904d9270fb771f6d3e9fac98b8b2",
+                "reference": "cc552c3562ab904d9270fb771f6d3e9fac98b8b2",
                 "shasum": ""
             },
             "require": {
@@ -4506,9 +4486,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "Common library for the OLCS Project",
             "support": {
-                "source": "https://github.com/dvsa/olcs-common/tree/v7.2.3"
+                "source": "https://github.com/dvsa/olcs-common/tree/v7.2.2"
             },
-            "time": "2024-05-22T10:35:22+00:00"
+            "time": "2024-05-21T08:50:36+00:00"
         },
         {
             "name": "olcs/olcs-logging",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2a7bd4a1a124b023469a98fb28e4e4e",
+    "content-hash": "a05613e550c86cf34af5989c280f5344",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4416,16 +4416,16 @@
         },
         {
             "name": "olcs/olcs-common",
-            "version": "v7.2.2",
+            "version": "v7.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-common.git",
-                "reference": "cc552c3562ab904d9270fb771f6d3e9fac98b8b2"
+                "reference": "221b1c97b2171e6e9edd34b088d81583236490bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/cc552c3562ab904d9270fb771f6d3e9fac98b8b2",
-                "reference": "cc552c3562ab904d9270fb771f6d3e9fac98b8b2",
+                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/221b1c97b2171e6e9edd34b088d81583236490bd",
+                "reference": "221b1c97b2171e6e9edd34b088d81583236490bd",
                 "shasum": ""
             },
             "require": {
@@ -4486,9 +4486,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "Common library for the OLCS Project",
             "support": {
-                "source": "https://github.com/dvsa/olcs-common/tree/v7.2.2"
+                "source": "https://github.com/dvsa/olcs-common/tree/v7.2.3"
             },
-            "time": "2024-05-21T08:50:36+00:00"
+            "time": "2024-05-22T10:35:22+00:00"
         },
         {
             "name": "olcs/olcs-logging",


### PR DESCRIPTION
## Description

Removed the dependence on our Laminas Form fork. The only practical difference from this is a bump from 3.19.1 to 3.19.2

Related issue: [VOL-5402](https://dvsa.atlassian.net/browse/VOL-5402)
