### PR TITLE
fix: fix count by `null` in `TransferVehicleController`

### DIFF
--- a/module/Olcs/src/Controller/Licence/Vehicle/TransferVehicleController.php
+++ b/module/Olcs/src/Controller/Licence/Vehicle/TransferVehicleController.php
@@ -107,8 +107,7 @@ class TransferVehicleController extends AbstractVehicleController
         $validationErrors = [];
         if (empty($selectedVehicles)) {
             $validationErrors[] = 'licence.vehicle.transfer.error.no-vehicle-selected';
-        }
-        if (count($selectedVehicles) > static::VEHICLE_TRANSFER_LIMIT) {
+        } elseif (count($selectedVehicles) > static::VEHICLE_TRANSFER_LIMIT) {
             $validationErrors[] = 'licence.vehicle.transfer.error.too-many-vehicles-selected';
         }
 


### PR DESCRIPTION
## Description

Tweaks the conditionals so that `null` isn't passed to the `count` call.

Related issue: https://dvsa.atlassian.net/browse/VOL-5465

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
