### PR TITLE
fix: resolve `array_key_exists` type error

### DIFF
--- a/module/Olcs/src/Controller/Licence/Vehicle/RemoveVehicleController.php
+++ b/module/Olcs/src/Controller/Licence/Vehicle/RemoveVehicleController.php
@@ -119,7 +119,7 @@ class RemoveVehicleController extends AbstractVehicleController
         $formData = $this->getRequest()->getQuery();
         $form->setData($formData);
 
-        if (array_key_exists('vehicleSearch', $formData)) {
+        if (array_key_exists('vehicleSearch', $formData->toArray())) {
             $form->isValid();
         }
 

--- a/module/Olcs/src/Controller/Licence/Vehicle/Reprint/ReprintLicenceVehicleDiscController.php
+++ b/module/Olcs/src/Controller/Licence/Vehicle/Reprint/ReprintLicenceVehicleDiscController.php
@@ -141,7 +141,7 @@ class ReprintLicenceVehicleDiscController extends AbstractVehicleController
         $formData = $request->getQuery();
         $form->setData($formData);
 
-        if (array_key_exists('vehicleSearch', $formData)) {
+        if (array_key_exists('vehicleSearch', $formData->toArray())) {
             $form->isValid();
         }
 

--- a/module/Olcs/src/Controller/Licence/Vehicle/TransferVehicleController.php
+++ b/module/Olcs/src/Controller/Licence/Vehicle/TransferVehicleController.php
@@ -215,7 +215,7 @@ class TransferVehicleController extends AbstractVehicleController
         $formData = $this->getRequest()->getQuery();
         $form->setData($formData);
 
-        if (array_key_exists('vehicleSearch', $formData)) {
+        if (array_key_exists('vehicleSearch', $formData->toArray())) {
             $form->isValid();
         }
 


### PR DESCRIPTION
## Description

Fixes the error when passing an object to `array_key_exists`. This was deprecated in PHP 7.4 and removed in PHP 8.0.

Related issue: https://dvsa.atlassian.net/browse/VOL-5463

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
