### PR TITLE
fix: remove return type from `PeopleController::deleteAction`

### DIFF
--- a/module/Olcs/src/Controller/Lva/Licence/PeopleController.php
+++ b/module/Olcs/src/Controller/Lva/Licence/PeopleController.php
@@ -107,10 +107,8 @@ class PeopleController extends Lva\AbstractPeopleController
 
     /**
      * Disallow deleting
-     *
-     * @return Response
      */
-    public function deleteAction(): Response
+    public function deleteAction()
     {
         $licencePeopleAdapter = $this->getLicencePeopleAdapter();
         $licencePeopleAdapter->loadPeopleData($this->lva, $this->getIdentifier());


### PR DESCRIPTION
## Description

This is not correct and would need fixing through various levels of inheritance.

Fixes:
```
TypeError : Olcs\\Controller\\Lva\\Licence\\PeopleController::deleteAction(): Return value must be of type Laminas\\Http\\Response, Laminas\\View\\Model\\ViewModel returned
```

Related issue: https://dvsa.atlassian.net/browse/VOL-5470

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
