### PR TITLE
fix: operator admins no longer see button to remove themselves

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4416,16 +4416,16 @@
         },
         {
             "name": "olcs/olcs-common",
-            "version": "v7.3.0",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dvsa/olcs-common.git",
-                "reference": "868d667b7f64af6634aef39e8ff5d1bc9480a976"
+                "reference": "726c5872413e5a50be2be399dc2dfd54314473af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/868d667b7f64af6634aef39e8ff5d1bc9480a976",
-                "reference": "868d667b7f64af6634aef39e8ff5d1bc9480a976",
+                "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/726c5872413e5a50be2be399dc2dfd54314473af",
+                "reference": "726c5872413e5a50be2be399dc2dfd54314473af",
                 "shasum": ""
             },
             "require": {
@@ -4486,9 +4486,9 @@
             "notification-url": "https://packagist.org/downloads/",
             "description": "Common library for the OLCS Project",
             "support": {
-                "source": "https://github.com/dvsa/olcs-common/tree/v7.3.0"
+                "source": "https://github.com/dvsa/olcs-common/tree/v7.4.0"
             },
-            "time": "2024-06-05T08:51:55+00:00"
+            "time": "2024-06-18T10:08:17+00:00"
         },
         {
             "name": "olcs/olcs-logging",

--- a/module/Olcs/src/Table/Tables/users.table.php
+++ b/module/Olcs/src/Table/Tables/users.table.php
@@ -66,7 +66,7 @@ return [
                  * @var TableBuilder $this
                  * @psalm-scope-this TableBuilder
                  */
-                $this->permissionService->canManageSelfserveUsers(),
+                $this->permissionService->canRemoveSelfserveUser($row['id']),
             'ariaDescription' => function ($row, $column) {
                 $column['formatter'] = Name::class;
                 /**


### PR DESCRIPTION
Operator admins no longer see button to remove themselves

## Description

selfserve users don't now have a button to remove themselves

Related issue: [VOL-5530](https://dvsa.atlassian.net/browse/VOL-5530)
